### PR TITLE
(fix): Fix the issue regarding cluster info missing

### DIFF
--- a/Kubernetes/pvc/Redis-pvc.yaml
+++ b/Kubernetes/pvc/Redis-pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: redis-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/Kubernetes/statefulsets/Redis-statefulset.yaml
+++ b/Kubernetes/statefulsets/Redis-statefulset.yaml
@@ -23,10 +23,14 @@ spec:
         - name: redis-config
           mountPath: /etc/redis
         - name: redis-data
-          mountPath: /data
+          mountPath: /data  # Stores nodes.conf and AOF/RDB files
+
       volumes:
-          - name: redis-config
-            configMap:
-              name: redis-config
-          - name: redis-data
-            emptyDir: {}  # Change to persistent storage if needed
+        - name: redis-config
+          configMap:
+            name: redis-config
+        # Remove 'emptyDir' and replace with a PVC
+        - name: redis-pvc
+          persistentVolumeClaim:
+            claimName: redis-pvc  # Reference to PVC
+


### PR DESCRIPTION
- Create a PVC for the Redis stateful set.
- Change the stateful set to connect to the PVC and remove the emptyDir attribute.